### PR TITLE
Raise Flutter to 3.13.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM mobiledevops/android-sdk-image:33.0.2
 
-ENV FLUTTER_VERSION="3.13.6"
+ENV FLUTTER_VERSION="3.13.8"
 ENV FLUTTER_HOME "/home/mobiledevops/.flutter-sdk"
 ENV PATH $PATH:$FLUTTER_HOME/bin
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM mobiledevops/android-sdk-image:33.0.2
 
-ENV FLUTTER_VERSION="3.10.3"
+ENV FLUTTER_VERSION="3.13.6"
 ENV FLUTTER_HOME "/home/mobiledevops/.flutter-sdk"
 ENV PATH $PATH:$FLUTTER_HOME/bin
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Currently:
 
 | Version  | Ref | Release Date |
 |---|---|---|
-| 3.13.6 | ead4559 | 27.09.2023 |
+| 3.13.8 | 6c4930c | 18.10.2023 |
 
 ## Releases
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Currently:
 
 | Version  | Ref | Release Date |
 |---|---|---|
-| 3.10.3 | f92f441 | 02.06.2021 |
+| 3.13.6 | ead4559 | 27.09.2023 |
 
 ## Releases
 


### PR DESCRIPTION
Raises the flutter version to 3.13.6

### Type of change

- [ ] bug fix
- [x] new feature
- [x] code style / documentation

### What does this implement/fix? Explain your changes.

Flutter version has been raised to 3.13.6 and also the readme has been updated.

