### PR TITLE
Updates to Flutter SDK 3.44.4

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/staging.yaml
+++ b/.github/workflows/staging.yaml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM mobiledevops/android-sdk-image:34.0.1
+FROM mobiledevops/android-sdk-image:36.1.0
 
-ENV FLUTTER_VERSION="3.19.4"
-ENV FLUTTER_HOME "/home/mobiledevops/.flutter-sdk"
-ENV PATH $PATH:$FLUTTER_HOME/bin
+ENV FLUTTER_VERSION="3.44.4"
+ENV FLUTTER_HOME="/home/mobiledevops/.flutter-sdk"
+ENV PATH="$PATH:$FLUTTER_HOME/bin"
 
 # Download and extract Flutter SDK
 RUN mkdir $FLUTTER_HOME \
@@ -10,5 +10,8 @@ RUN mkdir $FLUTTER_HOME \
     && curl --fail --remote-time --silent --location -O https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_${FLUTTER_VERSION}-stable.tar.xz \
     && tar xf flutter_linux_${FLUTTER_VERSION}-stable.tar.xz --strip-components=1 \
     && rm flutter_linux_${FLUTTER_VERSION}-stable.tar.xz
+
+# Git safe.directory for the extracted SDK (required since git 2.35+ ownership checks)
+RUN git config --global --add safe.directory $FLUTTER_HOME
 
 RUN flutter precache

--- a/README.md
+++ b/README.md
@@ -6,12 +6,13 @@ Currently:
 
 | Version  | Ref | Release Date |
 |---|---|---|
-| 3.19.4 | 68bfaea | 21.03.2023 |
+| 3.44.4 | ad70ec4 | 24.06.2026 |
 
 ## Releases
 
 | Tag | Flutter Version | Flutter Channel |
 |---|---|---|
+| 3.44.4 | 3.44.4 | stable |
 | 3.19.4 | 3.19.4 | stable |
 | 3.16.4 | 3.16.4 | stable|
 | 3.16.3 | 3.16.3 | stable|
@@ -71,7 +72,7 @@ version: 2.1
 jobs:
   build:
     docker: 
-      - image: mobiledevops/flutter-sdk-image:3.19.4
+      - image: mobiledevops/flutter-sdk-image:3.44.4
     steps:
       - checkout
       - run:
@@ -98,7 +99,7 @@ services:
   - docker
 
 env:
-  - DOCKER_IMAGE=mobiledevops/flutter-sdk-image:3.19.4
+  - DOCKER_IMAGE=mobiledevops/flutter-sdk-image:3.44.4
 
 before_install:
   - docker pull $DOCKER_IMAGE
@@ -120,7 +121,7 @@ Example:
 
 ```
 # .gitlab-ci.yml
-image: mobiledevops/flutter-sdk-image:3.19.4
+image: mobiledevops/flutter-sdk-image:3.44.4
 
 stages:
     - build


### PR DESCRIPTION
## Summary

Updates the image from Flutter 3.19.4 to **3.44.4** (latest stable, ref `ad70ec4`, Dart 3.12.2), verified with a full local `make build` + smoke test:

- Base image: `mobiledevops/android-sdk-image:34.0.1` → `:36.1.0` (build-tools 36.1.0, JDK 21, Gradle 9.6.1 — see MobileDevOps/android-sdk-image#16)
- `FLUTTER_VERSION` → 3.44.4
- New: `git config --global --add safe.directory $FLUTTER_HOME` — git 2.35+ ownership checks otherwise make `flutter precache` fail during build (and made `flutter --version` report "unknown source" at runtime in the published 3.19.4 image)
- Dockerfile style: legacy `ENV key value` → `ENV key=value`
- GitHub Actions: `actions/checkout@v3` → `v7`, `docker/login-action@v2` → `v4`
- README: current-version + releases tables, usage examples → 3.44.4

Note: the never-merged `feature/3.29.3` branch was skipped — no 3.29.3 tag/image was ever published, so master jumps 3.19.4 → 3.44.4.

## Dependency

⚠️ CI (`make build`) will fail until MobileDevOps/android-sdk-image#16 is merged and tag `36.1.0` is pushed there (publishes the base image to Docker Hub). Merge order: android-sdk-image first.

## Verification

- Local `make build` succeeds (base image tagged locally)
- `docker run --rm mobiledevops/flutter-sdk-image flutter --version` → Flutter 3.44.4 • stable • Dart 3.12.2, no git ownership warnings

After merge: push tag `3.44.4` to publish the image (release workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ndjGz2Ug42YwrSnkTLsCH